### PR TITLE
implement mini player

### DIFF
--- a/functions/.env
+++ b/functions/.env
@@ -1,4 +1,5 @@
 ﻿PROJECT_URL="https://vinylvision.web.app"
+#PROJECT_URL="http://localhost:5000"
 
 
 #Google Vision API Keys

--- a/functions/views/spotify-player.html
+++ b/functions/views/spotify-player.html
@@ -39,6 +39,11 @@
         <select name="artist_select" id="artist_select"></select><br><br>
         <input type="button" onclick="searchArtistAlbums()" value="Search Artist" />
     </div>
+
+    <div id="spotify-embed">
+        <iframe id="miniplayer" style="border-radius:12px" width="50%" height="380" frameBorder="0" allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture"></iframe>
+    </div>
+
     <br>
     <div id="logout">
         <a href="/spotify/logout">Back to Home Page</a>

--- a/public/js/player.js
+++ b/public/js/player.js
@@ -93,7 +93,11 @@ function nextSearchResult(j) {
 function displayAlbum(album) {
     //console.log(album)
     //console.log(album.name)
+    $("#miniplayer").attr(
+        "src", `https://open.spotify.com/embed/album/${album.id}?utm_source=generator&theme=0`
+    );
     document.getElementById("imageDiv").innerHTML = `<img src=${album.images[1].url} alt='${album.name} Album Cover' width='200px' height='200px'>`
+
 
     //add album name
     var albumNameDiv = document.getElementById("album_name")


### PR DESCRIPTION
Integrated the Spotify mini player into our code. It turns out users can actually listen to full songs using the mini player, or they can choose to be redirected to the full Spotify app by clicking the Spotify logo in the top right corner of the mini player.